### PR TITLE
Add clang-format style file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 120
+SortIncludes: false


### PR DESCRIPTION
Adds a clang-format style file in the root directory, which will then be used for formatting any subdirectories.